### PR TITLE
PHP8.2 Creation of dynamic property Hestia_Nginx_Cache::$admin is deprecated

### DIFF
--- a/hestia-nginx-cache.php
+++ b/hestia-nginx-cache.php
@@ -34,6 +34,9 @@ class Hestia_Nginx_Cache
 	public static $plugin_basename = null;
 	public static $is_configured = false;
 
+	public $admin = null;
+	public $site_health = null;
+
 	private $purge = false;
 
 	private $events = array(


### PR DESCRIPTION
Creation of dynamic property Hestia_Nginx_Cache::$site_health is deprecated and

Creation of dynamic property Hestia_Nginx_Cache::$admin is deprecated
